### PR TITLE
Initial work

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ if __name__ == '__main__':
 
 ```
 
-As long as you get an instance of `krux_boto.boto.Boto3`, the rest are the same. Refer to `krux_boto` module's [README](https://github.com/krux/python-krux-boto/blob/master/README.md) on various ways to instanciate the class.
+As long as you get an instance of `krux_boto.boto.Boto`, the rest are the same. Refer to `krux_boto` module's [README](https://github.com/krux/python-krux-boto/blob/master/README.md) on various ways to instanciate the class.

--- a/README.md
+++ b/README.md
@@ -34,4 +34,54 @@ if __name__ == '__main__':
 
 ```
 
+## Extending your application
+
+From other CLI applications, you can make the use of `krux_s3.s3.get_s3()` function.
+
+```python
+
+from krux_s3.s3 import add_s3_cli_arguments, get_s3
+import krux.cli
+
+class Application(krux.cli.Application):
+
+    def __init__(self, *args, **kwargs):
+        super(Application, self).__init__(*args, **kwargs)
+
+        self.d3 = get_s3(self.args, self.logger, self.stats)
+
+    def add_cli_arguments(self, parser):
+        super(Application, self).add_cli_arguments(parser)
+
+        add_s3_cli_arguments(parser)
+
+```
+
+Alternately, you want to add S3 functionality to your larger script or application.
+Here's how to do that:
+
+```python
+
+from krux_boto import Boto
+from krux_s3 import S3
+
+class MyApplication(object):
+
+    def __init__(self, *args, **kwargs):
+        boto = Boto(
+            logger=self.logger,
+            stats=self.stats,
+        )
+        self.s3 = S3(
+            boto=boto,
+            logger=self.logger,
+            stats=self.stats,
+        )
+
+    def run(self):
+        for key in self.s3.get_keys(bucket_name='my-test-bucket'):
+            print key.get_contents_as_string()
+
+```
+
 As long as you get an instance of `krux_boto.boto.Boto`, the rest are the same. Refer to `krux_boto` module's [README](https://github.com/krux/python-krux-boto/blob/master/README.md) on various ways to instanciate the class.

--- a/README.md
+++ b/README.md
@@ -8,25 +8,27 @@ In the current version, `krux_s3.s3.S3` is only compatible with `krux_boto.boto.
 
 ## Application quick start
 
-The most common use case is to build a CLI script using `krux_boto.cli.Application`.
+The most common use case is to build a CLI script using `krux_s3.cli.Application`.
 Here's how to do that:
 
 ```python
 
-from krux_boto.cli import Application
-from krux_s3.s3 import S3
+import krux_s3.cli
+
+# This class inherits from krux.cli.Application, so it provides
+# all that functionality as well.
+class Application(krux_s3.cli.Application):
+    def run(self):
+        for key in self.s3.get_keys(bucket_name='my-test-bucket'):
+            print key.get_contents_as_string()
 
 def main():
-    # The name must be unique to the organization. The object
-    # returned inherits from krux.cli.Application, so it provides
-    # all that functionality as well.
-    app = Application(name='krux-my-boto-script')
+    # The name must be unique to the organization.
+    app = Application(name='krux-my-s3-script')
+    with app.context():
+        app.run()
 
-    s3 = S3(boto=app.boto)
-    for key in s3.get_keys(bucket_name='my-test-bucket'):
-        print key.get_contents_as_string()
-
-### Run the application stand alone
+# Run the application stand alone
 if __name__ == '__main__':
     main()
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ class Application(krux.cli.Application):
     def __init__(self, *args, **kwargs):
         super(Application, self).__init__(*args, **kwargs)
 
-        self.d3 = get_s3(self.args, self.logger, self.stats)
+        self.s3 = get_s3(self.args, self.logger, self.stats)
 
     def add_cli_arguments(self, parser):
         super(Application, self).add_cli_arguments(parser)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # krux_s3
+
+`krux_s3` is a library that provides wrapper functions for common S3 usage. It uses `krux_boto` to connect to AWS S3.
+
+## Warning
+
+In the current version, `krux_s3.s3.S3` is only compatible with `krux_boto.boto.Boto` object. Passing other objects, such as `krux_boto.boto.Boto3`, will cause an exception.
+
+## Application quick start
+
+The most common use case is to build a CLI script using `krux_boto.cli.Application`.
+Here's how to do that:
+
+```python
+
+from krux_boto.cli import Application
+from krux_s3.s3 import S3
+
+def main():
+    # The name must be unique to the organization. The object
+    # returned inherits from krux.cli.Application, so it provides
+    # all that functionality as well.
+    app = Application(name='krux-my-boto-script')
+
+    s3 = S3(boto=app.boto)
+    for key in s3.get_keys(bucket_name='my-test-bucket'):
+        print key.get_contents_as_string()
+
+### Run the application stand alone
+if __name__ == '__main__':
+    main()
+
+```
+
+As long as you get an instance of `krux_boto.boto.Boto3`, the rest are the same. Refer to `krux_boto` module's [README](https://github.com/krux/python-krux-boto/blob/master/README.md) on various ways to instanciate the class.

--- a/krux_s3/cli.py
+++ b/krux_s3/cli.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# © 2016 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+import os
+
+#
+# Internal libraries
+#
+
+from krux.cli import get_group
+import krux_boto.cli
+from krux_s3.s3 import add_s3_cli_arguments, get_s3, NAME
+
+
+class Application(krux_boto.cli.Application):
+
+    def __init__(self, name=NAME):
+        # Call to the superclass to bootstrap.
+        super(Application, self).__init__(name=name)
+
+        self.s3 = get_s3(self.args, self.logger, self.stats)
+
+    def add_cli_arguments(self, parser):
+        # Call to the superclass
+        super(Application, self).add_cli_arguments(parser)
+
+        add_s3_cli_arguments(parser, include_boto_arguments=False)
+
+    def run(self):
+        print self.s3.get_keys(
+            bucket_name='krux-tmp'
+        )
+
+
+def main():
+    app = Application()
+    with app.context():
+        app.run()
+
+
+# Run the application stand alone
+if __name__ == '__main__':
+    main()

--- a/krux_s3/s3.py
+++ b/krux_s3/s3.py
@@ -102,6 +102,7 @@ class S3(object):
         self._stats = stats or get_stats(prefix=self._name)
 
         # Throw exception when Boto2 is not used
+        # TODO: Start using Boto3 and reverse this check
         if not isinstance(boto, Boto):
             raise TypeError('krux_s3.s3.S3 only supports krux_boto.boto.Boto')
 

--- a/krux_s3/s3.py
+++ b/krux_s3/s3.py
@@ -104,7 +104,7 @@ class S3(object):
         self._logger = logger or get_logger(self._name)
         self._stats = stats or get_stats(prefix=self._name)
 
-        # Add the boto connector
+        # Throw exception when Boto2 is not used
         if not isinstance(boto, Boto):
             raise TypeError('krux_s3.s3.S3 only supports krux_boto.boto.Boto')
 

--- a/krux_s3/s3.py
+++ b/krux_s3/s3.py
@@ -55,23 +55,20 @@ class S3(object):
 
     def __init__(
         self,
+        boto,
         logger=None,
         stats=None,
-        parser=None,
     ):
         # Private variables, not to be used outside this module
         self._name = NAME
         self._logger = logger or get_logger(self._name)
         self._stats = stats or get_stats(prefix=self._name)
-        self._parser = parser or get_parser(description=self._name)
-        self._args = self._parser.parse_args()
 
         # Add the boto connector
-        self.boto = Boto(
-            parser=self._parser,
-            logger=self._logger,
-            stats=self._stats,
-        )
+        if not isinstance(boto, Boto):
+            raise TypeError('krux_s3.s3.S3 only supports krux_boto.boto.Boto')
+
+        self.boto = boto
 
         # Set up default cache
         self._conn = None

--- a/krux_s3/s3.py
+++ b/krux_s3/s3.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+#
+# © 2015 Krux Digital, Inc.
+#
+
+# TODO: This is currently inside krux_manage_instance library.
+# However, consider breaking this into a separate library or add it to krux_boto library.
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+from pprint import pprint
+
+#
+# Third party libraries
+#
+
+import boto.s3
+
+#
+# Internal libraries
+#
+
+from krux_boto import Boto, add_boto_cli_arguments
+from krux.logging import get_logger
+from krux.stats import get_stats
+from krux.cli import get_parser, get_group
+
+
+NAME = 'krux-s3'
+
+
+def add_s3_cli_arguments(parser, include_boto_arguments=True):
+    """
+    Utility function for adding S3 specific CLI arguments.
+    """
+    if include_boto_arguments:
+        # GOTCHA: Since EC2 and S3 both uses Boto, the Boto's CLI arguments can be included twice,
+        # causing an error. This creates a way to circumvent that.
+
+        # Add all the boto arguments
+        add_boto_cli_arguments(parser)
+
+    # Add those specific to the application
+    group = get_group(parser, NAME)
+
+
+class S3(object):
+    """
+    A manager to handle all S3 related functions.
+    Each instance is locked to a connection to a designated region (self.boto.cli_region).
+    """
+
+    def __init__(
+        self,
+        logger=None,
+        stats=None,
+        parser=None,
+    ):
+        # Private variables, not to be used outside this module
+        self._name = NAME
+        self._logger = logger or get_logger(self._name)
+        self._stats = stats or get_stats(prefix=self._name)
+        self._parser = parser or get_parser(description=self._name)
+        self._args = self._parser.parse_args()
+
+        # Add the boto connector
+        self.boto = Boto(
+            parser=self._parser,
+            logger=self._logger,
+            stats=self._stats,
+        )
+
+        # Set up default cache
+        self._conn = None
+        self._buckets = {}
+
+    def _get_connection(self):
+        """
+        Returns a connection to the designated region (self.boto.cli_region).
+        The connection is established on the first call for this instance (lazy) and cached.
+        """
+        if self._conn is None:
+            self._conn = self.boto.s3.connect_to_region(self.boto.cli_region)
+
+        return self._conn
+
+    def _get_bucket(self, bucket_name):
+        """
+        Returns a bucket with the given name.
+        The bucket is fetched on the first call (lazy) and cached.
+        """
+        if bucket_name not in self._buckets or self._buckets[bucket_name] is None:
+            self._buckets[bucket_name] = self._get_connection().get_bucket(bucket_name)
+
+        return self._buckets[bucket_name]
+
+    def get_keys(self, bucket_name, prefix=None):
+        """
+        Returns a list of keys with the given prefix under the given bucket.
+        """
+        bucket = self._get_bucket(bucket_name)
+
+        keys = bucket.get_all_keys(prefix=prefix)
+
+        self._logger.info('Found following keys: %s', keys)
+        return keys
+
+    def create_key(self, bucket_name, key, str_content):
+        """
+        Creates a key in the given bucket.
+
+        The key parameter is used as the key of the newly created key.
+        The str_content parameter is used as the content of the newly created key.
+
+        If there is another key with the same key in the given bucket, an error is thrown.
+        """
+        bucket = self._get_bucket(bucket_name)
+
+        k = self.boto.s3.key.Key(bucket)
+        k.key = key
+
+        if k.exists():
+            raise ValueError('Entry {0} already exists in S3 -- delete it first'.format(key.Key))
+
+        k.set_contents_from_string(str_content)
+
+        self._logger.info(
+            'Created a key %s in bucket %s with following contents: %s',
+            key, bucket_name, str_content
+        )
+
+        return k
+
+    def update_key(self, bucket_name, key, str_content):
+        """
+        Updates a key in the given bucket.
+
+        The key parameter is used to fetch the key.
+        The str_content parameter overwrites the content of the key.
+        """
+        bucket = self._get_bucket(bucket_name)
+
+        k = bucket.get_key(key)
+
+        if k is None:
+            raise ValueError('There are no key with name {0}'.format(key))
+
+        k.set_contents_from_string(str_content)
+
+        self._logger.info(
+            'Updated a key %s in bucket %s with following contents: %s',
+            key, bucket_name, str_content
+        )
+
+        return k
+
+    def remove_keys(self, bucket_name, keys):
+        """
+        Deletes the given keys from the given bucket.
+        """
+        bucket = self._get_bucket(bucket_name)
+
+        self._logger.info('Deleting following keys: %s', keys)
+        bucket.delete_keys(keys)

--- a/krux_s3/s3.py
+++ b/krux_s3/s3.py
@@ -32,6 +32,46 @@ from krux.cli import get_parser, get_group
 NAME = 'krux-s3'
 
 
+def get_s3(args=None, logger=None, stats=None):
+    """
+    Return a usable Sqs object without creating a class around it.
+
+    In the context of a krux.cli (or similar) interface the 'args', 'logger'
+    and 'stats' objects should already be present. If you don't have them,
+    however, we'll attempt to provide usable ones for the SQS setup.
+
+    (If you omit the add_s3_cli_arguments() call during other cli setup,
+    the Boto object will still work, but its cli options won't show up in
+    --help output)
+
+    (This also handles instantiating a Boto object on its own.)
+    """
+    if not args:
+        parser = get_parser()
+        add_s3_cli_arguments(parser)
+        args = parser.parse_args()
+
+    if not logger:
+        logger = get_logger(name=NAME)
+
+    if not stats:
+        stats = get_stats(prefix=NAME)
+
+    boto = Boto(
+        log_level=args.boto_log_level,
+        access_key=args.boto_access_key,
+        secret_key=args.boto_secret_key,
+        region=args.boto_region,
+        logger=logger,
+        stats=stats,
+    )
+    return S3(
+        boto=boto,
+        logger=logger,
+        stats=stats,
+    )
+
+
 def add_s3_cli_arguments(parser, include_boto_arguments=True):
     """
     Utility function for adding S3 specific CLI arguments.

--- a/krux_s3/s3.py
+++ b/krux_s3/s3.py
@@ -3,9 +3,6 @@
 # © 2015 Krux Digital, Inc.
 #
 
-# TODO: This is currently inside krux_manage_instance library.
-# However, consider breaking this into a separate library or add it to krux_boto library.
-
 #
 # Standard libraries
 #

--- a/krux_s3/s3.py
+++ b/krux_s3/s3.py
@@ -34,7 +34,7 @@ NAME = 'krux-s3'
 
 def get_s3(args=None, logger=None, stats=None):
     """
-    Return a usable Sqs object without creating a class around it.
+    Return a usable S3 object without creating a class around it.
 
     In the context of a krux.cli (or similar) interface the 'args', 'logger'
     and 'stats' objects should already be present. If you don't have them,

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
+            'krux-s3-test = krux_s3.cli:main',
         ],
     },
     test_suite='test',

--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# © 2016 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+from datetime import datetime
+import unittest
+
+#
+# Internal libraries
+#
+
+from krux_boto.boto import Boto
+from krux_s3.s3 import S3
+
+
+class S3Test(unittest.TestCase):
+    TEST_BUCKET = 'krux-tmp'
+    TEST_KEY = 'TEST-KEY-{timestamp}'
+    TEST_CONTENT = 'TEST-TEST'
+
+    def setUp(self):
+        self._s3 = S3(
+            boto=Boto()
+        )
+
+        self._timestamp = (datetime.utcnow() - datetime.utcfromtimestamp(0)).total_seconds()
+
+    def test_get_keys(self):
+        """
+        S3 data is correctly returned as a list
+        """
+        # TODO: This test needs to be improved using mock and stuff. But for the interest of time,
+        # let's leave it at this minimal state.
+        self.assertIsInstance(self._s3.get_keys(bucket_name=self.TEST_BUCKET), list)
+
+    def test_create_update_delete_keys(self):
+        """
+        Keys can be created, updated, and deleted from S3
+        """
+        # TODO: This test needs to be improved using mock and stuff. But for the interest of time,
+        # let's leave it at this minimal state.
+        self._s3.create_key(
+            bucket_name=self.TEST_BUCKET,
+            key=self.TEST_KEY.format(timestamp=self._timestamp),
+            str_content=self.TEST_CONTENT,
+        )
+        self._s3.update_key(
+            bucket_name=self.TEST_BUCKET,
+            key=self.TEST_KEY.format(timestamp=self._timestamp),
+            str_content=self.TEST_CONTENT,
+        )
+        self._s3.remove_keys(
+            bucket_name=self.TEST_BUCKET,
+            keys=[self.TEST_KEY.format(timestamp=self._timestamp)],
+        )


### PR DESCRIPTION
Thin wrapper for S3, just like [python-krux-boto-sqs](https://github.com/krux/python-krux-boto-sqs).

98% of the code in `krux_s3.s3.py` is copy and paste from [python-krux-manage-instance](https://github.com/krux/python-krux-manage-instance/blob/master/krux_s3/s3.py), and thus reviewed before.