### PR TITLE
Allow S3 to take in session tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ class MyApplication(object):
     def __init__(self, *args, **kwargs):
         boto = Boto(
             access_key='my-access-key',
-            access_key='my-secret-key',
+            secret_key='my-secret-key',
         )
         self.s3 = S3(
             boto=boto,

--- a/krux_s3/cli.py
+++ b/krux_s3/cli.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# © 2016 Krux Digital, Inc.
+# © 2015-2016 Krux Digital, Inc.
 #
 
 #

--- a/krux_s3/s3.py
+++ b/krux_s3/s3.py
@@ -158,7 +158,7 @@ class S3(object):
         k.key = key
 
         if k.exists():
-            raise ValueError('Entry {0} already exists in S3 -- delete it first'.format(key.Key))
+            raise ValueError('Entry {0} already exists in S3 -- delete it first'.format(k.key))
 
         k.set_contents_from_string(str_content)
 

--- a/krux_s3/s3.py
+++ b/krux_s3/s3.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# © 2015 Krux Digital, Inc.
+# © 2015-2016 Krux Digital, Inc.
 #
 
 #

--- a/krux_s3/s3.py
+++ b/krux_s3/s3.py
@@ -15,6 +15,7 @@ from pprint import pprint
 #
 
 import boto.s3
+import boto.s3.connection
 
 #
 # Internal libraries
@@ -93,6 +94,7 @@ class S3(object):
     def __init__(
         self,
         boto,
+        security_token=None,
         logger=None,
         stats=None,
     ):
@@ -107,6 +109,7 @@ class S3(object):
             raise TypeError('krux_s3.s3.S3 only supports krux_boto.boto.Boto')
 
         self.boto = boto
+        self._security_token = security_token
 
         # Set up default cache
         self._conn = None
@@ -118,7 +121,9 @@ class S3(object):
         The connection is established on the first call for this instance (lazy) and cached.
         """
         if self._conn is None:
-            self._conn = self.boto.s3.connect_to_region(self.boto.cli_region)
+            self._conn = self.boto.s3.connection.S3Connection(
+                security_token=self._security_token,
+            )
 
         return self._conn
 

--- a/requirements.pip
+++ b/requirements.pip
@@ -2,7 +2,7 @@
 --extra-index-url https://staticfiles.krxd.net/foss/pypi/
 
 # Krux-boto library which this is built on
-krux-boto==1.0.1
+krux-boto==1.0.2
 
 # Transitive libraries
 # This is needed so there are no version conflicts when
@@ -10,7 +10,7 @@ krux-boto==1.0.1
 # and another one does.
 
 # From krux-boto
-krux-stdlib==2.1.1
+krux-stdlib==2.1.4
 boto==2.39.0
 boto3==1.2.3
 pystache==0.5.4
@@ -18,8 +18,8 @@ Sphinx==1.2b1
 Jinja2==2.6
 Pygments==1.6
 docutils==0.10
-kruxstatsd==0.2.2
-statsd==2.0.3
+kruxstatsd==0.2.4
+statsd==2.0.3  # statsd is pegged at 2.0.3 by kruxstatsd
 argparse==1.2.1
 GitPython==0.3.2.RC1
 simplejson==3.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+description-file = README.md
+
+[nosetests]
+cover-branches = 1
+cover-html = 1
+cover-inclusive = 1
+cover-package = krux_s3
+verbosity = 2
+with-coverage = 1
+with-id = 1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '0.0.1'
+VERSION = '0.1.0'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto-s3'

--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# © 2016 Krux Digital, Inc.
+# © 2015-2016 Krux Digital, Inc.
 #
 
 #

--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -135,6 +135,9 @@ class S3Test(unittest.TestCase):
         self.assertFalse(mock_get_bucket.called)
 
     def test_get_keys(self):
+        """
+        get_keys() properly returns a list of keys
+        """
         mock_get_bucket = MagicMock()
         mock_get_bucket.return_value.get_all_keys.return_value = [self.TEST_KEY]
 
@@ -147,6 +150,9 @@ class S3Test(unittest.TestCase):
         self._logger.info.assert_called_once_with('Found following keys: %s', [self.TEST_KEY])
 
     def test_create_key(self):
+        """
+        create_key() properly creates a key under the given bucket with the given content
+        """
         mock_get_bucket = MagicMock()
         self._s3._get_bucket = mock_get_bucket
 
@@ -166,6 +172,9 @@ class S3Test(unittest.TestCase):
         )
 
     def test_create_key_duplicate(self):
+        """
+        create_key() properly throws an error when there is another key with the same name
+        """
         mock_key = self._boto.s3.key.Key.return_value
         mock_key.exists.return_value = True
 
@@ -178,6 +187,9 @@ class S3Test(unittest.TestCase):
         )
 
     def test_update_key(self):
+        """
+        update_key() properly update a key under the given bucket with the given content
+        """
         mock_get_bucket = MagicMock()
         mock_key = mock_get_bucket.return_value.get_key.return_value
         self._s3._get_bucket = mock_get_bucket
@@ -194,6 +206,9 @@ class S3Test(unittest.TestCase):
         )
 
     def test_update_key_none(self):
+        """
+        update_key() properly throws an error when there is no key with the same name
+        """
         mock_get_bucket = MagicMock()
         mock_get_bucket.return_value.get_key.return_value = None
         self._s3._get_bucket = mock_get_bucket
@@ -207,6 +222,9 @@ class S3Test(unittest.TestCase):
         )
 
     def test_remove_keys(self):
+        """
+        remove_keys() properly deletes the keys under the given bucket
+        """
         mock_get_bucket = MagicMock()
 
         self._s3._get_bucket = mock_get_bucket

--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -173,6 +173,35 @@ class S3Test(unittest.TestCase):
             str(e.exception)
         )
 
+    def test_update_key(self):
+        mock_get_bucket = MagicMock()
+        mock_key = mock_get_bucket.return_value.get_key.return_value
+        self._s3._get_bucket = mock_get_bucket
+
+        key = self._s3.update_key(self.TEST_BUCKET, self.TEST_KEY, self.TEST_CONTENT)
+
+        self.assertEqual(mock_key, key)
+        mock_get_bucket.assert_called_once_with(self.TEST_BUCKET)
+        mock_get_bucket.return_value.get_key.assert_called_once_with(self.TEST_KEY)
+        mock_key.set_contents_from_string.assert_called_once_with(self.TEST_CONTENT)
+        self._logger.info.assert_called_once_with(
+            'Updated a key %s in bucket %s with following contents: %s',
+            self.TEST_KEY, self.TEST_BUCKET, self.TEST_CONTENT
+        )
+
+    def test_update_key_none(self):
+        mock_get_bucket = MagicMock()
+        mock_get_bucket.return_value.get_key.return_value = None
+        self._s3._get_bucket = mock_get_bucket
+
+        with self.assertRaises(ValueError) as e:
+            self._s3.update_key(self.TEST_BUCKET, self.TEST_KEY, self.TEST_CONTENT)
+
+        self.assertEqual(
+            'There are no key with name {0}'.format(self.TEST_KEY),
+            str(e.exception)
+        )
+
     def test_remove_keys(self):
         mock_get_bucket = MagicMock()
 


### PR DESCRIPTION
#### What's this PR do?
This PR add following two things:
* Unit test for `krux_s3.s3.S3` class
* Ability to support STS assumed role

#### How was this PR manually tested?
The change was manually tested on the development environment

#### Any background context you want to provide?
* The unit test should make this library easier to improve in the future.
* This allows us to use other accounts, similar to how we use `--profile` CLI option in AWS CLI.